### PR TITLE
[Design/#1] 디자인 토큰 추가 및 Pretendard 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ node_modules
 
 #!.yarn/cache
 .pnp.*
+
+# Turborepo local build cache
+.turbo/

--- a/apps/admin/app/app.css
+++ b/apps/admin/app/app.css
@@ -1,2 +1,2 @@
-@import "tailwindcss";
 @import "@mamokey/ui/globals.css";
+@import "tailwindcss";

--- a/apps/admin/app/app.css
+++ b/apps/admin/app/app.css
@@ -1,15 +1,2 @@
 @import "tailwindcss";
-
-@theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
-
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
-}
+@import "@mamokey/ui/globals.css";

--- a/apps/admin/app/root.tsx
+++ b/apps/admin/app/root.tsx
@@ -10,22 +10,9 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 
-export const links: Route.LinksFunction = () => [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
-  {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous",
-  },
-  {
-    rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
-  },
-];
-
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/apps/home/app/app.css
+++ b/apps/home/app/app.css
@@ -1,2 +1,2 @@
-@import "tailwindcss";
 @import "@mamokey/ui/globals.css";
+@import "tailwindcss";

--- a/apps/home/app/app.css
+++ b/apps/home/app/app.css
@@ -1,15 +1,2 @@
 @import "tailwindcss";
-
-@theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
-
-html,
-body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
-}
+@import "@mamokey/ui/globals.css";

--- a/apps/home/app/root.tsx
+++ b/apps/home/app/root.tsx
@@ -10,22 +10,9 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 
-export const links: Route.LinksFunction = () => [
-  { rel: "preconnect", href: "https://fonts.googleapis.com" },
-  {
-    rel: "preconnect",
-    href: "https://fonts.gstatic.com",
-    crossOrigin: "anonymous",
-  },
-  {
-    rel: "stylesheet",
-    href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
-  },
-];
-
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="ko">
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "exports": {
     ".": "./src/index.ts",
+    "./globals.css": "./src/globals.css",
     "./components/*": "./src/components/*.tsx"
   },
   "scripts": {

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -18,72 +18,72 @@
 
   --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 
-  --font-size-main-title: 200px;
-  --font-size-section-title: 55px;
-  --font-size-section-subtitle: 28px;
-  --font-size-item-title: 34px;
-  --font-size-title-description: 25px;
-  --font-size-section-body: 20px;
-  --font-size-nav-button: 23px;
-  --font-size-cta: 20px;
+  --font-size-title-1: 200px;
+  --font-size-title-2: 55px;
+  --font-size-title-3: 34px;
+  --font-size-title-4: 28px;
+  --font-size-body-1: 25px;
+  --font-size-body-2: 20px;
+  --font-size-button-1: 23px;
+  --font-size-button-2: 20px;
 
-  --line-height-main-title: 170px;
-  --line-height-title-description: 35px;
-  --line-height-section-body: 32px;
-  --line-height-nav-button: 30px;
+  --line-height-title-1: 170px;
+  --line-height-body-1: 35px;
+  --line-height-body-2: 32px;
+  --line-height-button-1: 30px;
 }
 
-@utility text-main-title {
-  font-size: var(--font-size-main-title);
+@utility text-title-1 {
+  font-size: var(--font-size-title-1);
   font-weight: 400;
-  line-height: var(--line-height-main-title);
+  line-height: var(--line-height-title-1);
   font-family: var(--font-sans);
 }
 
-@utility text-section-title {
-  font-size: var(--font-size-section-title);
+@utility text-title-2 {
+  font-size: var(--font-size-title-2);
   font-weight: 500;
   line-height: 100%;
   font-family: var(--font-sans);
 }
 
-@utility text-section-subtitle {
-  font-size: var(--font-size-section-subtitle);
-  font-weight: 600;
-  line-height: 100%;
-  font-family: var(--font-sans);
-}
-
-@utility text-item-title {
-  font-size: var(--font-size-item-title);
+@utility text-title-3 {
+  font-size: var(--font-size-title-3);
   font-weight: 700;
   line-height: 100%;
   font-family: var(--font-sans);
 }
 
-@utility text-title-description {
-  font-size: var(--font-size-title-description);
-  font-weight: 400;
-  line-height: var(--line-height-title-description);
+@utility text-title-4 {
+  font-size: var(--font-size-title-4);
+  font-weight: 600;
+  line-height: 100%;
   font-family: var(--font-sans);
 }
 
-@utility text-section-body {
-  font-size: var(--font-size-section-body);
+@utility text-body-1 {
+  font-size: var(--font-size-body-1);
   font-weight: 400;
-  line-height: var(--line-height-section-body);
+  line-height: var(--line-height-body-1);
   font-family: var(--font-sans);
 }
 
-@utility text-nav-button {
-  font-size: var(--font-size-nav-button);
+@utility text-body-2 {
+  font-size: var(--font-size-body-2);
+  font-weight: 400;
+  line-height: var(--line-height-body-2);
+  font-family: var(--font-sans);
+}
+
+@utility text-button-1 {
+  font-size: var(--font-size-button-1);
   font-weight: 300;
-  line-height: var(--line-height-nav-button);
+  line-height: var(--line-height-button-1);
   font-family: var(--font-sans);
 }
 
-@utility text-cta {
-  font-size: var(--font-size-cta);
+@utility text-button-2 {
+  font-size: var(--font-size-button-2);
   font-weight: 600;
   line-height: 100%;
   font-family: var(--font-sans);

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -1,0 +1,82 @@
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css");
+
+@theme {
+  --color-black: #000000;
+  --color-white: #f9f9f9;
+  --color-pure-white: #ffffff;
+  --color-blue: #003edf;
+  --color-blue-light: #c9d4f8;
+  --color-navy: #20369d;
+
+  --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+
+  --font-size-main-title: 200px;
+  --font-size-section-title: 55px;
+  --font-size-section-subtitle: 28px;
+  --font-size-item-title: 34px;
+  --font-size-title-description: 25px;
+  --font-size-section-body: 20px;
+  --font-size-nav-button: 23px;
+  --font-size-cta: 20px;
+
+  --line-height-main-title: 170px;
+  --line-height-title-description: 35px;
+  --line-height-section-body: 32px;
+  --line-height-nav-button: 30px;
+}
+
+@utility text-main-title {
+  font-size: var(--font-size-main-title);
+  font-weight: 400;
+  line-height: var(--line-height-main-title);
+  font-family: var(--font-sans);
+}
+
+@utility text-section-title {
+  font-size: var(--font-size-section-title);
+  font-weight: 500;
+  line-height: 100%;
+  font-family: var(--font-sans);
+}
+
+@utility text-section-subtitle {
+  font-size: var(--font-size-section-subtitle);
+  font-weight: 600;
+  line-height: 100%;
+  font-family: var(--font-sans);
+}
+
+@utility text-item-title {
+  font-size: var(--font-size-item-title);
+  font-weight: 700;
+  line-height: 100%;
+  font-family: var(--font-sans);
+}
+
+@utility text-title-description {
+  font-size: var(--font-size-title-description);
+  font-weight: 400;
+  line-height: var(--line-height-title-description);
+  font-family: var(--font-sans);
+}
+
+@utility text-section-body {
+  font-size: var(--font-size-section-body);
+  font-weight: 400;
+  line-height: var(--line-height-section-body);
+  font-family: var(--font-sans);
+}
+
+@utility text-nav-button {
+  font-size: var(--font-size-nav-button);
+  font-weight: 300;
+  line-height: var(--line-height-nav-button);
+  font-family: var(--font-sans);
+}
+
+@utility text-cta {
+  font-size: var(--font-size-cta);
+  font-weight: 600;
+  line-height: 100%;
+  font-family: var(--font-sans);
+}

--- a/packages/ui/src/globals.css
+++ b/packages/ui/src/globals.css
@@ -4,9 +4,17 @@
   --color-black: #000000;
   --color-white: #f9f9f9;
   --color-pure-white: #ffffff;
-  --color-blue: #003edf;
-  --color-blue-light: #c9d4f8;
-  --color-navy: #20369d;
+
+  --color-blue-50:  #eef3ff;
+  --color-blue-100: #c9d4f8;
+  --color-blue-200: #98baff;
+  --color-blue-300: #6f9aff;
+  --color-blue-400: #3f6eff;
+  --color-blue-500: #003edf;
+  --color-blue-600: #0034c2;
+  --color-blue-700: #20369d;
+  --color-blue-800: #1a2b7e;
+  --color-blue-900: #111c52;
 
   --font-sans: "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
 


### PR DESCRIPTION
## 연관 Issue
- closes #1

## 요약
`packages/ui/src/global.css`에 공통 디자인 토큰(색상/타이포)을 추가하고, home/admin 앱에서 사용하도록 import를 추가했습니다.

## 변경 사항
- `globals.css`에 Figma 기반 색상/타이포그래피 토큰 정의
- Pretendard Variable 폰트 CDN 적용
- home/admin `app.css`에서 `@mamokey/ui/globals.css` import
- home/admin `root.tsx`에서 Inter 제거, `lang="ko"` 변경
- `.gitignore`에 `.turbo/` 추가

## 범위
### 포함
- 공통 색상/타이포그래피 디자인 토큰 정의
- Pretendard Variable 폰트 적용
- home/admin 앱에서 글로벌 스타일 import
- `root.tsx` 기본 설정 수정

### 제외
- Button/Input 등 UI 컴포넌트 구현
- 레이아웃 컴포넌트(Navbar/Footer 등)
- 페이지 UI 구현

## 스크린샷 / 미리 보기
- home/admin dev 실행 시 디자인 토큰 정상 적용 확인
- home/admin dev 실행 시 Pretendard 폰트 정상 적용 확인
<img width="3840" height="2944" alt="screencapture-localhost-5173-2026-03-08-15_43_23" src="https://github.com/user-attachments/assets/05eecac0-d6db-4df0-bc98-a0d36849cc41" />